### PR TITLE
Not for merge: set Bevy version to 0.8.0-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,4 @@ web-sys = { version = "0.3.57", features = ["Element", "Document", "Window"] }
 
 [dependencies.bevy]
 default-features = false
-version = "0.7.0"
-# git = "https://github.com/bevyengine/bevy"
-# rev = "8b27124a801d83a1e92f1136ebd2bc9752c3e9d7"
+version = "0.8.0-dev"


### PR DESCRIPTION
Hi there!

I've set up a fork that changes the version to 0.8.0-dev, so that people using a patch like
```toml
[patch.crates-io]
bevy = {git = 'https://github.com/bevyengine/bevy.git'}
```
can use this package with no troubles.

This isn't meant to be merged - it's just so that other people who are also using this with Bevy 0.8 know where to look. This is the only change that's been needed so far, but I'll keep this up to date if any more come across my plate 🙏 