### PR TITLE
Update to bevy 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ version = "0.2.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-futures = "0.3.21"
-gloo-events = "0.1.2"
-web-sys = { version = "0.3.57", features = ["Element", "Document", "Window"] }
+futures = "0.3"
+gloo-events = "0.1"
+web-sys = { version = "0.3", features = ["Element", "Document", "Window"] }
 
 [dependencies.bevy]
 default-features = false
-version = "0.8.0"
+version = "0.9"
 # git = "https://github.com/bevyengine/bevy"
 # rev = "8b27124a801d83a1e92f1136ebd2bc9752c3e9d7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{App, Plugin, Res, ResMut},
+    prelude::{App, Plugin, Res, ResMut, Resource},
     window::Windows,
 };
 use std::sync::{
@@ -7,19 +7,21 @@ use std::sync::{
     Mutex,
 };
 
-type OnResizeSender = Sender<()>;
-type OnResizeReceiver = Receiver<()>;
+#[derive(Resource)]
+struct OnResizeSender(Mutex<Sender<()>>);
+#[derive(Resource)]
+struct OnResizeReceiver(Mutex<Receiver<()>>);
 
 pub struct FullViewportPlugin;
 
 impl Plugin for FullViewportPlugin {
     fn build(&self, app: &mut App) {
         let channel = std::sync::mpsc::channel();
-        let resize_sender: OnResizeSender = channel.0;
-        let resize_receiver: OnResizeReceiver = channel.1;
+        let resize_sender = OnResizeSender(Mutex::new(channel.0));
+        let resize_receiver = OnResizeReceiver(Mutex::new(channel.1));
 
-        app.insert_resource(Mutex::new(resize_sender))
-            .insert_resource(Mutex::new(resize_receiver))
+        app.insert_resource(resize_sender)
+            .insert_resource(resize_receiver)
             .add_startup_system(setup_viewport_resize_system)
             .add_system(viewport_resize_system);
     }
@@ -39,9 +41,9 @@ fn get_viewport_size() -> (f32, f32) {
     (width as f32, height as f32)
 }
 
-fn setup_viewport_resize_system(resize_sender: Res<Mutex<OnResizeSender>>) {
+fn setup_viewport_resize_system(resize_sender: Res<OnResizeSender>) {
     let web_window = web_sys::window().expect("could not get window");
-    let local_sender = resize_sender.lock().unwrap().clone();
+    let local_sender = resize_sender.0.lock().unwrap().clone();
 
     local_sender.send(()).unwrap();
 
@@ -53,9 +55,9 @@ fn setup_viewport_resize_system(resize_sender: Res<Mutex<OnResizeSender>>) {
 
 fn viewport_resize_system(
     mut windows: ResMut<Windows>,
-    resize_receiver: Res<Mutex<OnResizeReceiver>>,
+    resize_receiver: Res<OnResizeReceiver>,
 ) {
-    if resize_receiver.lock().unwrap().try_recv().is_ok() {
+    if resize_receiver.0.lock().unwrap().try_recv().is_ok() {
         if let Some(window) = windows.get_primary_mut() {
             let size = get_viewport_size();
             window.set_resolution(size.0, size.1);


### PR DESCRIPTION
The current version fails to compile with bevy 0.9 due to `Resource` no longer being automatically implemented on all suitable types.
The solution is to make a wrapper type and derive `Resource` on it. This also solves a potential issue if another lib or the end user also wants to use a `Mutex<Sender<()>>` as a resource (which is why bevy now requires you to do this).